### PR TITLE
Fix wrong indentation compared to default export icons

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -1,3 +1,6 @@
 #exportxmla:before {
   content: "";
 }
+#exportxml{
+  margin-left:-4px;
+}


### PR DESCRIPTION
Adapted from https://github.com/JohnMcLear/ep_markdown/blob/master/templates/exportcolumn.html#L8-L10
